### PR TITLE
feat: set the server url in bux-console and hide it

### DIFF
--- a/apps/bux-console/deployment.yml
+++ b/apps/bux-console/deployment.yml
@@ -22,12 +22,18 @@ spec:
     spec:
       containers:
         - name: bux-console
-          image: 4chainstudio/bux-console:v0.2.0-RC1
-          imagePullPolicy: IfNotPresent
-          envFrom:
-            - configMapRef:
-                name: bux-console-env
+          image: buxorg/bux-console:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: env-config
+              mountPath: /usr/share/nginx/html/env-config.json
+              subPath: env-config.json
+              readOnly: true
           ports:
             - containerPort: 3000
               name: web
               protocol: TCP
+      volumes:
+        - name: env-config
+          configMap:
+            name: bux-console-env

--- a/apps/bux-console/environment.yml
+++ b/apps/bux-console/environment.yml
@@ -5,5 +5,9 @@ metadata:
   labels:
     app: bux-console
 data:
-  ROOT_URL: 'https://bux-console.DOMAIN_NAME_TLD/'
-  METEOR_SETTINGS: '{}'
+  env-config.json: |
+    {
+      "serverUrl": "https://bux.DOMAIN_NAME_TLD",
+      "hideServerUrl": false
+    }
+    


### PR DESCRIPTION
The changes includes:
- use buxorg image of bux-console instead of custom one
- add a configuration override config
- set server url and hide server url properties in config.

@sirdeggen To make it working, we need a new release of bux-console therefore, wait for it before merge or applying changes.

EDIT:
bux-console docker image is already updated, so it's ready to use.